### PR TITLE
Use ConsatMapper for import of consat stops

### DIFF
--- a/src/Services/ConsatImporter.php
+++ b/src/Services/ConsatImporter.php
@@ -82,6 +82,10 @@ class ConsatImporter
 
     /**
      * Sort csvs by priority.
+     *
+     * Manually override the order the CSVs are handed over to ConsatMapper.
+     * This is useful to force some tables to be loaded before other in case
+     * they depend on each other.
      */
     protected function prioritizeCsvs(array $csvs)
     {

--- a/src/Services/ConsatImporter.php
+++ b/src/Services/ConsatImporter.php
@@ -13,13 +13,16 @@ class ConsatImporter
 {
     protected $importRecordCount = 0;
 
+    /**
+     * Map of CSVs to eloquent model.
+     */
     protected $csvModelMap = [
+        'StopPoint.csv' => \Ragnarok\Consat\Models\Stop::class,
         'CallDetails.csv' => \Ragnarok\Consat\Models\CallDetail::class,
         'Calls.csv' => \Ragnarok\Consat\Models\Call::class,
+        'Destination.csv' => \Ragnarok\Consat\Models\Destination::class,
         'PassengerCount.csv' => \Ragnarok\Consat\Models\PassengerCount::class,
         'PlannedJourneys.csv' => \Ragnarok\Consat\Models\PlannedJourney::class,
-        'StopPoint.csv' => \Ragnarok\Consat\Models\Stop::class,
-        'Destination.csv' => \Ragnarok\Consat\Models\Destination::class,
     ];
 
     /**
@@ -32,26 +35,9 @@ class ConsatImporter
         $this->importRecordCount = 0;
         $extractor = new ZipExtractor($file);
         $extractor->extractContent();
-
-        // Load stop points first and prepare for NSR quay mapping.
-        $stopFilePath = sprintf('%s/StopPoint.csv', $extractor->getFullOutputDir());
-        $stopData = [];
-        if (($handle = fopen($stopFilePath, 'r')) !== false) {
-            $csvCols = fgetcsv($handle, 0, ';');
-            while (($values = fgetcsv($handle, 0, ';')) !== false) {
-                if (count($csvCols) !== count($values)) continue;
-                $csvRow = array_combine($csvCols, $values);
-                $stopData[$csvRow['Id']] = [
-                    'id' => $csvRow['ExternalId'],
-                    'name' => $csvRow['Name'],
-                ];
-            }
-            fclose($handle);
-        }
-
-        $mapFactory = new ConsatMapper($extractor->getDisk(), $stopData);
+        $mapFactory = new ConsatMapper($extractor->getDisk());
         $this->addMapperExceptions($mapFactory, $dateStr);
-        foreach ($extractor->getFiles() as $csvFile) {
+        foreach ($this->prioritizeCsvs($extractor->getFiles()) as $csvFile) {
             $mapper = $mapFactory->getMapper($csvFile);
             if (!$mapper) {
                 continue;
@@ -95,6 +81,20 @@ class ConsatImporter
     public function getCsvModel(string $csv): string|null
     {
         return $this->csvModelMap[$csv] ?? null;
+    }
+
+    /**
+     * Sort csvs by priority.
+     */
+    protected function prioritizeCsvs(array $csvs)
+    {
+        $order = ['StopPoint.csv' => 1];
+        usort($csvs, function ($alice, $bob) use ($order) {
+            $aWeight = $order[basename($alice)] ?? 1000;
+            $bWeight = $order[basename($bob)] ?? 1000;
+            return $aWeight - $bWeight;
+        });
+        return $csvs;
     }
 
     /**

--- a/src/Services/ConsatImporter.php
+++ b/src/Services/ConsatImporter.php
@@ -13,16 +13,13 @@ class ConsatImporter
 {
     protected $importRecordCount = 0;
 
-    /**
-     * Map of CSVs to eloquent model.
-     */
     protected $csvModelMap = [
-        'StopPoint.csv' => \Ragnarok\Consat\Models\Stop::class,
         'CallDetails.csv' => \Ragnarok\Consat\Models\CallDetail::class,
         'Calls.csv' => \Ragnarok\Consat\Models\Call::class,
-        'Destination.csv' => \Ragnarok\Consat\Models\Destination::class,
         'PassengerCount.csv' => \Ragnarok\Consat\Models\PassengerCount::class,
         'PlannedJourneys.csv' => \Ragnarok\Consat\Models\PlannedJourney::class,
+        'StopPoint.csv' => \Ragnarok\Consat\Models\Stop::class,
+        'Destination.csv' => \Ragnarok\Consat\Models\Destination::class,
     ];
 
     /**

--- a/src/Services/ConsatMapper.php
+++ b/src/Services/ConsatMapper.php
@@ -33,12 +33,10 @@ class ConsatMapper
 
     /**
      * @param Filesystem $disk Laravel disk/filesystem the csv files is found
-     * @param array $consatStops Array of stop/quay info
      */
-    public function __construct(Filesystem $disk, array $consatStops)
+    public function __construct(Filesystem $disk)
     {
         $this->csvDisk = $disk;
-        $this->stopMap = $consatStops;
     }
 
     public function except(string $csvFile): ConsatMapper
@@ -146,6 +144,12 @@ class ConsatMapper
         $mapper->column('Name', 'name')->required();
         $mapper->column('Latitude', 'latitude');
         $mapper->column('Longitude', 'longitude');
+        $mapper->preInsertRecord(function ($record) {
+            $this->stopMap[$record['Id']] = [
+                'id' => $record['ExternalId'],
+                'name' => $record['Name'],
+            ];
+        });
         return $mapper;
     }
 

--- a/src/Services/ConsatMapper.php
+++ b/src/Services/ConsatMapper.php
@@ -144,6 +144,9 @@ class ConsatMapper
         $mapper->column('Name', 'name')->required();
         $mapper->column('Latitude', 'latitude');
         $mapper->column('Longitude', 'longitude');
+        // Hash/cache stop points. This is used by self::mapCalls() to add NSR
+        // quays (and stop names) directly instead of the internal (regtopp)
+        // stop point IDs.
         $mapper->preInsertRecord(function ($record) {
             $this->stopMap[$record['Id']] = [
                 'id' => $record['ExternalId'],


### PR DESCRIPTION
Consat data is in iso-8859-1, and trying to import this without encoding conversion causes production setup to choke.

To mitigate this, this pr will move handling of importing and mapping of stop places in its entirety to ConsatMapper. The only snag here is that the StopPoint.csv has to be prioritized first, so som clutter code is added to ConsatImporter :-/