### PR TITLE
fix: Don't log already logged import summary

### DIFF
--- a/src/Services/ConsatImporter.php
+++ b/src/Services/ConsatImporter.php
@@ -39,7 +39,7 @@ class ConsatImporter
             if (!$mapper) {
                 continue;
             }
-            $this->importRecordCount += $mapper->exec()->logSummary()->getProcessedRecords();
+            $this->importRecordCount += $mapper->exec()->getProcessedRecords();
         }
         $extractor->cleanUp();
         return $this;


### PR DESCRIPTION
The fix is done in ragnarok-sink, but as a minor context leakage, there was double up with logged messages. This removes the duplicate `->logSummary()`, that already was executed in CsvMapper.php